### PR TITLE
Gaithersburg qualifiers fixes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutonomousSpecimenObservation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutonomousSpecimenObservation.java
@@ -46,25 +46,25 @@ public class AutonomousSpecimenObservation extends LinearOpMode {
                 axial = 1;
                 robotController.update(0, 0, 0, axial, lateral, 0, false, true, false,
                         false, false);
-            } else if(elapsedTime < 4.0){
+            } else if(elapsedTime < 4.3){
                 //push the arm down a bit to place the specimen on the bar
                 shoulderCommand = -1;
                 robotController.setArmMode(ArmMode.DRIVER_CONTROL);
                 robotController.update(shoulderCommand, 0, 0,
                         0, 0, 0, false, true, false,
                         false, false);
-            } else if(elapsedTime < 4.5){
+            } else if(elapsedTime < 4.8){
                 //make the claw let go of the specimen
                 clawClosed = false;
                 robotController.update(0, 0, 0,
                         0, 0, 0, false, false, false,
                         false, false);
-            } else if(elapsedTime < 7.0){
+            } else if(elapsedTime < 7.3){
                 //make the robot go backwards to the wall
                 axial = -1;
                 robotController.update(0, 0, 0, axial, 0, 0, false, true, false,
                         false, false);
-            } else if(elapsedTime < 12.0){
+            } else if(elapsedTime < 12.3){
                 // do what noah said and move the robot to the park zone
                 robotController.setArmMode(ArmMode.GRAB_SPECIMEN);
                 lateral = 1;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Main_Teleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Main_Teleop.java
@@ -35,6 +35,7 @@ public class Main_Teleop extends LinearOpMode {
             } else {
                 climberDrive = 0;
             }
+            robotController.setClimberOverride(gamepad1.a);
 
             if (gamepad2.left_bumper) {
                 clawClosed = true;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/control/ArmController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/control/ArmController.java
@@ -74,6 +74,9 @@ public class ArmController {
                 SHOULDER_KP, SHOULDER_KI, SHOULDER_KD);
         linearSlidePID = new PositionPIDController(linear_slide_motor,
                 LINEAR_SLIDE_KP, LINEAR_SLIDE_KI, LINEAR_SLIDE_KD);
+
+        desiredShoulderPos = shoulder_motor_1.getCurrentPosition();
+        desiredLinearSlidePos = linear_slide_motor.getCurrentPosition();
     }
 
     public void update(double shoulderCommand, double linearSlideCommand, boolean overrideArmLowLimits, Telemetry telemetry) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/control/RobotController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/control/RobotController.java
@@ -28,6 +28,8 @@ public class RobotController {
     private DcMotor rightFrontDrive = null;
     private DcMotor rightBackDrive = null;
 
+    private boolean climberOverride = false;
+
     private final ArmController armController = new ArmController();
 
     public void init(HardwareMap hardwareMap, Telemetry telemetry, boolean zeroEncoders) {
@@ -77,7 +79,11 @@ public class RobotController {
     }
 
     private void assignMotorPowers(double climber_drive, double clawPos, WheelPower wheelPower) {
-        climber.setPower(climber_drive);
+        if (climber.getCurrentPosition() < 0 || climber_drive < 0 || climberOverride) {
+            climber.setPower(climber_drive);
+        } else {
+            climber.setPower(0);
+        }
 
         claw.setPosition(clawPos);
 
@@ -85,6 +91,10 @@ public class RobotController {
         rightFrontDrive.setPower(wheelPower.rightFrontPower);
         leftBackDrive.setPower(wheelPower.leftBackPower);
         rightBackDrive.setPower(wheelPower.rightBackPower);
+    }
+
+    public void setClimberOverride(boolean override) {
+        climberOverride = override;
     }
 
     @NonNull


### PR DESCRIPTION
Set starting desired position to the current encoder positions at the start of teleop for the shoulder and linear slide so the controller doesn't move.

Adjust the timing of lowering the shoulder for specimen auto because the specimen was not clipping onto the rung.

Add a soft limit to the climber because the hooks could trap the rung against the linear slide motor.

Before issuing a pull request, please see the contributing page.
